### PR TITLE
Bump fastcomments-java to 0.0.20

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ activityCompose = "1.8.0"
 composeBom = "2024.04.01"
 appcompat = "1.7.0"
 material = "1.12.0"
-fastcomments = "0.0.19"
+fastcomments = "0.0.20"
 constraintlayout = "2.1.4"
 swiperefreshlayout = "1.1.0"
 

--- a/libraries/sdk/src/main/java/com/fastcomments/sdk/FastCommentsSDK.java
+++ b/libraries/sdk/src/main/java/com/fastcomments/sdk/FastCommentsSDK.java
@@ -48,7 +48,6 @@ public class FastCommentsSDK {
     public int currentPage;
     public int currentSkip;
     public int pageSize = 30;
-    public long lastGenDate;
     public Set<String> broadcastIdsSent;
     public String blockingErrorMessage;
 
@@ -230,7 +229,6 @@ public class FastCommentsSDK {
                     .skipChildren(skip)
                     .limit(limit)
                     .limitChildren(limit)
-                    .lastGenDate(lastGenDate)
                     .includeConfig(includeConfig)
                     .countAll(Boolean.TRUE.equals(config.countAll))
                     .countChildren(true)
@@ -301,7 +299,6 @@ public class FastCommentsSDK {
                     .skipChildren(skip)
                     .limit(limit)
                     .limitChildren(limit)
-                    .lastGenDate(lastGenDate)
                     .countChildren(true)
                     .locale(config.locale)
                     .executeAsync(new ApiCallback<GetCommentsPublic200Response>() {


### PR DESCRIPTION
lastGenDate was removed from the api and is uneeded when using asTree